### PR TITLE
Api v2 - corrected handling of boolean filter parameters in list_finding

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -795,13 +795,13 @@ class DefectDojoAPIv2(object):
         if limit:
             params['limit'] = limit
 
-        if active:
+        if active is not None:
             params['active'] = active
 
-        if duplicate:
+        if duplicate is not None:
             params['duplicate'] = duplicate
 
-        if mitigated:
+        if mitigated is not None:
             params['mitigated'] = mitigated
 
         if severity:


### PR DESCRIPTION
So far boolean filter_parameters were not evaluated correctly if a 'False' value was passed.